### PR TITLE
Show also current in overview video?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'requests',
         'smart_fact_crawler==0.3.1',
         'send2trash',
+        'selenium',
     ],
     entry_points={'console_scripts': [
         'la_palma_overview = la_palma_overview.__init__:main',


### PR DESCRIPTION
Adrian an me were talking about the lid, and what if the lid does not fully open. The system would not realize that and the starting shifter might not notice this in a webcam or so.. 
So we might take happily data with a half open lid.

I think, this is more or less okay, as long as we realize this at least during the next day ... and not after a week or month....

So we though, the overview video should maybe include something like the currents ... this would show a half open lid ... 

And also ... I think, we get a nice handle on spotting hardware defects ... for just one minute of video ...
So I researched how to make screenshots of websites using javascript. And found a lot of ways involving hard to install stuff. 

The easiest by far for me seemed `selenium`, which is pip installable. Together with `PhantomJS`, which is `apt-get`, `homebrew` and `npm` installable, so I hope this can even run on Travis, in case we wanna go for testing. 

At the moment, this will fail with such an exception (in the logs)
```
selenium.common.exceptions.WebDriverException: Message: 'phantomjs' executable needs to be in PATH.
```
resulting in the same black images, we get when the webcam page is down or so.

In case `phantomjs` was not installed e.g. like this:
```
sudo apt-get install phantomjs
```
