### PR TITLE
point out font dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ Make nightly overview videos of the Roque observatory on La Palma or just save s
 
 ![img](example_images/overview.gif)
 
+## Dependencies
+Needs ```DejaVuSansMono.ttf```.
+```bash
+user@machine:~$ sudo apt-get install fonts-dejavu-core
+```
+
 ## Video
 ##### Usage
 ```bash


### PR DESCRIPTION
```PIL``` expects fonts to be installed.  If the fonts can not be found on the system, the 'time' and 'status' images do not have any red text and remain black. This happened [lately](http://fact-project.org/overview_video/2017/08/21/images/000000.jpg) when la_palma_overview was moved to newdata which did not have the fonts in question.

stdout on newdata:
```bash
2017-08-22 07:57:23|ERROR|la_palma_overview|Failed to create clock image
Traceback (most recent call last):
  File "/home/fact/anaconda3/lib/python3.5/site-packages/la_palma_overview/__init__.py", line 284, in save_image
    imgs.append(clock2img(cfg['img']['rows'], cfg['img']['cols']))
  File "/home/fact/anaconda3/lib/python3.5/site-packages/la_palma_overview/__init__.py", line 49, in clock2img
    font_time = ImageFont.truetype('DejaVuSansMono.ttf', size=120)
  File "/home/fact/anaconda3/lib/python3.5/site-packages/PIL/ImageFont.py", line 239, in truetype
    return FreeTypeFont(font, size, index, encoding)
  File "/home/fact/anaconda3/lib/python3.5/site-packages/PIL/ImageFont.py", line 128, in __init__
    self.font = core.getfont(font, size, index, encoding)
OSError: cannot open resource
```

At the moment I do not know how to fix this to be pip installable. I have the feeling that we might be able to bring the font file ourselves in the package resources and then tell ```PIL``` to use this font file. But at the moment it should at least be mentioned in the README.md
